### PR TITLE
Improve hyperlinking of legal notice fields

### DIFF
--- a/files/lib/page/LegalNoticePage.class.php
+++ b/files/lib/page/LegalNoticePage.class.php
@@ -31,7 +31,8 @@ class LegalNoticePage extends AbstractPage {
 		parent::assignVariables();
 		
 		WCF::getTPL()->assign([
-			'encodedEmailAddress' => StringUtil::encodeAllChars(LEGAL_NOTICE_EMAIL_ADDRESS)
+			'encodedEmailAddress' => StringUtil::encodeAllChars(LEGAL_NOTICE_EMAIL_ADDRESS),
+			'encodedUriEmailAddress' => StringUtil::encodeAllChars(rawurlencode(LEGAL_NOTICE_EMAIL_ADDRESS)),
 		]);
 	}
 }

--- a/templates/legalNotice.tpl
+++ b/templates/legalNotice.tpl
@@ -18,12 +18,12 @@
 		
 		{if LEGAL_NOTICE_PHONE}
 			<dt>{lang}wcf.legalNotice.phone{/lang}</dt>
-			<dd>{LEGAL_NOTICE_PHONE}</dd>
+			<dd><a href="tel:{LEGAL_NOTICE_PHONE|rawurlencode}">{LEGAL_NOTICE_PHONE}</a></dd>
 		{/if}
 		
 		{if LEGAL_NOTICE_FAX}
 			<dt>{lang}wcf.legalNotice.fax{/lang}</dt>
-			<dd>{LEGAL_NOTICE_FAX}</dd>
+			<dd><a href="tel:{LEGAL_NOTICE_FAX|rawurlencode}">{LEGAL_NOTICE_FAX}</a></dd>
 		{/if}
 		
 		{if LEGAL_NOTICE_REPRESENTATIVE}

--- a/templates/legalNotice.tpl
+++ b/templates/legalNotice.tpl
@@ -13,7 +13,7 @@
 		
 		{if $encodedEmailAddress}
 			<dt>{lang}wcf.legalNotice.emailAddress{/lang}</dt>
-			<dd><a href="mailto:{@$encodedEmailAddress}">{@$encodedEmailAddress}</a></dd>
+			<dd><a href="mailto:{@$encodedUriEmailAddress}">{@$encodedEmailAddress}</a></dd>
 		{/if}
 		
 		{if LEGAL_NOTICE_PHONE}


### PR DESCRIPTION
- Hyperlink phone numbers with the `tel:` URI scheme. (Closes #7)
- Fix generated URLs for email addresses with special characters by URL-encoding the value within the `href`.